### PR TITLE
Issue #4 - Password reset token showing

### DIFF
--- a/src/Cerad/Bundle/AppBundle/Resources/views/AccountPassword/ResetEmail/AccountPasswordResetEmailBody.html.twig
+++ b/src/Cerad/Bundle/AppBundle/Resources/views/AccountPassword/ResetEmail/AccountPasswordResetEmailBody.html.twig
@@ -2,7 +2,7 @@
 
 A password reset request has been made for: {{ user.username }}.
 
-Your confirmation number is:  {{ userToken }}
+Your password reset token is:  {{ userToken }}
 
 Please enter this number on the site password reset confirmation page.
 

--- a/src/Cerad/Bundle/AppBundle/Resources/views/AccountPassword/ResetRequested/AccountPasswordResetRequestedHelp.html.twig
+++ b/src/Cerad/Bundle/AppBundle/Resources/views/AccountPassword/ResetRequested/AccountPasswordResetRequestedHelp.html.twig
@@ -4,10 +4,10 @@
 <legend>Need Help?</legend>
 <ul class="cerad_common_help" style="width: 600px;">
     <li>
-        Your Password Reset Token is: {{ userToken }}
+        Check your spam folder if you did not receive a reset email.
     </li>
     <li>
-        Enter your new password and press the button.
+        Enter the 4-digit token sent in the email and your new password.
     </li>
 </ul>
 


### PR DESCRIPTION
Do not show the password reset token on the reset requested page.  Though I do admit I kind of liked it there even though it was not secure.  Saves problems with emails ending up in the spam folder.
